### PR TITLE
fix #93: build on linux

### DIFF
--- a/makefile
+++ b/makefile
@@ -1,0 +1,38 @@
+TGT_DIR := lib
+HPP_DIR := src/libHellweg2D
+H_DIR := src/physics
+SRC_PATH := $(H_DIR):$(HPP_DIR)
+vpath %.cpp $(SRC_PATH)
+INCLUDES := $(wildcard $(HPP_DIR)/*.hpp) $(wildcard $(H_DIR)/*.h)
+SRC := $(foreach d, $(subst :, ,$(SRC_PATH)), $(wildcard $(d)/*.cpp)) $(TGT_DIR)/pyhellweg.cpp
+OBJ :=$(addprefix $(TGT_DIR)/,$(notdir $(SRC:%.cpp=%.o)))
+TGT := $(TGT_DIR)/pyhellweg.cpython-37m-x86_64-linux-gnu.so
+INSTALL_DIR :=  $(shell python -c 'import sysconfig; print(sysconfig.get_path("purelib"))')/rslinac
+PY_PLATINCLUDE := $(shell python -c 'import sysconfig; print(sysconfig.get_path("platinclude"))')
+PY_INCLUDE := $(shell python -c 'import sysconfig; print(sysconfig.get_path("data"))')/include
+LOCAL_INCLUDE := $(HOME)/.local/include
+CPPFLAGS := -pthread -Wno-unused-result -Wsign-compare -DNDEBUG -g -fwrapv -O3 -Wall -fPIC -DRSLINAC=1 -I$(HPP_DIR) -I$(H_DIR) -I$(PY_PLATINCLUDE) -I$(PY_INCLUDE) -I$(LOCAL_INCLUDE) -std=c++11
+
+LDFLAGS := -shared -L/home/vagrant/.pyenv/versions/3.7.2/lib #TODO(robnagler) needs to be pulled from setup.py; do not include $CPPFLAGS
+
+all: $(TGT)
+
+install: all
+	install -m 555 $(TGT) $(INSTALL_DIR)/$(notdir $(TGT))
+
+clean:
+	rm -rf $(TGT_DIR)
+
+$(TGT_DIR)/pyhellweg.cpp: pyhellweg.pyx
+	cython --cplus $^ -o $@
+
+$(OBJ): $(INCLUDES) $(TGT_DIR)
+
+$(TGT_DIR):
+	mkdir $@
+
+$(TGT_DIR)/%.o: %.cpp
+	$(COMPILE.cpp) $(OUTPUT_OPTION) $<
+
+$(TGT): $(OBJ)
+	$(LINK.cpp) $^ $(LOADLIBES) $(LDLIBS) -o $@

--- a/pyhellweg.pyx
+++ b/pyhellweg.pyx
@@ -1,3 +1,4 @@
+# cython: language_level=3
 import subprocess as sp
 
 def unmangle_cpp_class(mangled_str):
@@ -48,7 +49,7 @@ def run_beam_solver(ini_path, input_path, output_path):
         else:
             raise PyHellwegInputError(err_info.msg)
 
-cdef class PyHellwegBeamSolver(object):
+cdef class PyHellwegBeamSolver:
     cdef HellwegBeamSolver *_solver
 
     def __init__(self, ini_path, input_path):

--- a/rslinac/solver.py
+++ b/rslinac/solver.py
@@ -6,25 +6,27 @@ u"""Python to C++ Proxy interface for Solvers
 """
 import rslinac.pyhellweg
 
+def _b(o):
+    return str(o).encode('utf-8')
 
 class BeamSolver(object):
     def __init__(self, ini_path, input_path):
         self._solver = rslinac.pyhellweg.PyHellwegBeamSolver(
-            str(ini_path),
-            str(input_path),
+            _b(ini_path),
+            _b(input_path),
         )
 
     def solve(self):
         self._solver.solve()
 
     def dump_bin(self, output_path):
-        self._solver.dump_bin(str(output_path))
+        self._solver.dump_bin(_b(output_path))
 
     def get_structure_parameters(self, param):
         return self._solver.get_structure_parameters(param)
 
     def load_bin(self, input_path):
-        self._solver.load_bin(str(input_path))
+        self._solver.load_bin(_b(input_path))
 
     def save_output(self, output_path):
-        self._solver.save_output(str(output_path))
+        self._solver.save_output(_b(output_path))

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ def _get_compile_args():
     compiler = os.environ.get('CC', sysconfig.get_config_var('CC'))
     # libHellweg2D uses c++11 features
     if 'gcc' in compiler:
-        return ['-std=c++11']
+        return ['-std=c++11', '-I/home/vagrant/.local/include']
     return None
 
 
@@ -55,7 +55,7 @@ pksetup.setup(
             language='c++',
             sources=_get_src_files(_PHYS_DIR, 'cpp') +
                 _get_src_files(_LIB_DIR, 'cpp') +
-                ['pyhellweg.cpp'],
+                ['lib/pyhellweg.cpp'],
             extra_compile_args=_get_compile_args(),
         ),
     ],

--- a/src/libHellweg2D/AnsiString.cpp
+++ b/src/libHellweg2D/AnsiString.cpp
@@ -7,6 +7,10 @@ int AnsiString::Length() const {
     return s.length();
 }
 
+bool AnsiString::IsEmpty() const {
+    return s.length() == 0;
+}
+
 const char& AnsiString::operator[](size_t i) const {
     assert(i > 0);
     // http://docs.embarcadero.com/products/rad_studio/radstudio2007/RS2007_helpupdates/HUpdate4/EN/html/delphivclwin32/System__AnsiString__[]@int.html
@@ -36,6 +40,10 @@ bool AnsiString::operator==(const AnsiString &other) const {
     return s == other.s;
 }
 
+bool AnsiString::operator==(const std::string &other) const {
+    return s == other;
+}
+
 bool AnsiString::operator==(const char *other) const {
     return s == std::string(other);
 }
@@ -46,6 +54,10 @@ bool operator!=(const char* c, const AnsiString &as) {
 
 bool AnsiString::operator!=(const AnsiString &other) const {
     return s != other.s;
+}
+
+bool AnsiString::operator!=(const std::string &other) const {
+    return s != other;
 }
 
 bool AnsiString::operator!=(const char *other) const {

--- a/src/libHellweg2D/AnsiString.hpp
+++ b/src/libHellweg2D/AnsiString.hpp
@@ -23,8 +23,10 @@ class AnsiString {
         
         bool operator==(const AnsiString &other) const;
         bool operator==(const char *other) const;
+        bool operator==(const std::string &other) const;
         bool operator!=(const AnsiString &other) const;
         bool operator!=(const char *other) const;
+        bool operator!=(const std::string &other) const;
 
         AnsiString operator+(const char *other) const;
         AnsiString operator+(const AnsiString &other) const;
@@ -36,6 +38,7 @@ class AnsiString {
         AnsiString& operator+=(const char &other); 
 
         int Length() const;
+        bool IsEmpty() const;
 };
 
 std::ostream& operator<<(std::ostream &strm, const AnsiString &a);

--- a/src/physics/BeamSolver.cpp
+++ b/src/physics/BeamSolver.cpp
@@ -4027,7 +4027,7 @@ double TBeamSolver::GetEigenFactor(double x, double y, double z,double a, double
 			else if (cph<=-1)
 				phi=pi;
 			else
-				ShowMessage("Big boom badaboom!");
+				assert(false);
 
 
 			r=2*rho;

--- a/src/physics/Functions.h
+++ b/src/physics/Functions.h
@@ -118,7 +118,7 @@ inline double PulseToAngle(double beta_x,double beta_z)
 	return mod(beta_z) > 0? arctg(beta_x/beta_z) : sign(beta_x)*pi/2;
 }
 //---------------------------------------------------------------------------
-inline CompressPhase(double &phi)
+inline void CompressPhase(double &phi)
 {
 	int phase_dig=-DigitConst*phi;
 	int max_dig=DigitConst*2*pi;
@@ -421,7 +421,7 @@ static AnsiString GetLine(ifstream &f)   //Reads the next line from fstream
 	do {
 		f.getline(s, sizeof(s)) ;
 		S=AnsiString(s);
-	} while(S.IsEmpty() || S==' ');
+	} while(S.IsEmpty() || S==" ");
 
 	return S;
 }


### PR DESCRIPTION
Some additional methods were needed in the AnsiString class to compare directly to std::string. The operators implementations on AnsiString are incomplete and std::string versions are missing from some of the operators. I only added what was needed to compile.

There is an 'assert(false)' added to one of the math functions. Previously there was a call to a GUI method but it was unclear if the function should fail or continue in the case it normally would have raised a message. The message appeared to be a joke.

The changes to the Cython and tests was transferred from https://github.com/radiasoft/rslinac/tree/88-wip-fix-build.

The GUI code is excluded by the makefile at the moment. It is contained within src/gui which is not a folder targeted by the makefile.

The branch passes the test included in the branch but more testing is needed to make sure it did not lose any unintended functionality.