### PR TITLE
Fix #158: Protect Beam being null

### DIFF
--- a/src/physics/BeamSolver.cpp
+++ b/src/physics/BeamSolver.cpp
@@ -299,9 +299,11 @@ bool TBeamSolver::LoadFromFile(AnsiString& Fname)
 
     delete[] Structure;
 
-    for (int i=0;i<Np_beam;i++)
-        delete Beam[i];
-    delete[] Beam;
+    if (Beam) {
+        for (int i=0;i<Np_beam;i++)
+            delete Beam[i];
+        delete[] Beam;
+    }
 
     Beam=new TBeam*[Npoints];
     for (int i=0;i<Npoints;i++)


### PR DESCRIPTION
When calling LoadFromFile Beam may be uninitialized (ex BeamSolver hasn't run a solve). Protect against this case so we don't delte a nullptr which results in a segfault.